### PR TITLE
Handle directories that are numbers

### DIFF
--- a/js/UI.js
+++ b/js/UI.js
@@ -1162,7 +1162,17 @@ var UI = (function(){
                 var content_ui = content.getItemUI();
                 if(content_ui.data('mpd_file_path')){
                     //this is only for directories
-                    var relative_path = content_ui.data('mpd_file_path').replace(path+'/', '');
+                    var file_path = content_ui.data('mpd_file_path');
+                    //if file_path is a number (e.g. "311"), we need to convert to a string first
+                    var relative_path = null;
+                    if( typeof(file_path) == "number" )
+                    {
+		      relative_path = file_path.toString().replace(path+'/', '');
+                    }
+                    else
+                    {
+                      relative_path = content_ui.data('mpd_file_path').replace(path+'/', '');
+                    }
                     content_ui.find('.LIST_directory_path').html(relative_path);
                 }
                 //append the directory to it's parent's children

--- a/js/UI.js
+++ b/js/UI.js
@@ -1171,7 +1171,7 @@ var UI = (function(){
                     }
                     else
                     {
-                      relative_path = content_ui.data('mpd_file_path').replace(path+'/', '');
+                      relative_path = file_path.replace(path+'/', '');
                     }
                     content_ui.find('.LIST_directory_path').html(relative_path);
                 }


### PR DESCRIPTION
My directory structure has lots of folders that the code thought was a number and not a string. ("311" probably being the most notable example) This causes an exception to throw since numbers don't have a "replace" method defined. The fix is simply to handle this case and convert to a string first.

(Full disclosure: I am a javascript newbie. I tested this fix though and it works great 👍 )