### PR TITLE
Fixed connecting using secured websockets

### DIFF
--- a/js/mpd.js
+++ b/js/mpd.js
@@ -1943,7 +1943,7 @@ function MPD(_port, _host, _password){
           protocol = "wss://";
           url = url.substr(8);
       }
-      if(url.substring(0, 3) == "wss"){
+      else if(url.substring(0, 3) == "wss"){
           protocol = "wss://";
           url = url.substr(6);
       }


### PR DESCRIPTION
Due to a missing else keyword, regardless of whether a HTTPS connection was detected a non-secured WebSocket would be used.

The bug broke the application when being served from a secure origin (aka, over HTTPS), since in that case most modern browers will disallow the use of non-secured websockets.